### PR TITLE
Upgrade nippy dependency to 2.7.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
   :description "a in-process task-queue that is backed by disk."
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[com.taoensso/nippy "2.5.2"]
+  :dependencies [[com.taoensso/nippy "2.7.0"]
                  [primitive-math "0.1.3"]
                  [byte-streams "0.1.9"]
                  [manifold "0.1.0-alpha3"]]

--- a/src/durable_queue.clj
+++ b/src/durable_queue.clj
@@ -199,7 +199,7 @@
               ary (bs/to-byte-array (.position buf header-size))]
           (when-not (== (checksum (.getInt buf 10) ary) checksum')
             (throw (IOException. "checksum mismatch")))
-          (nippy/thaw-from-bytes ary))))))
+          (nippy/thaw ary))))))
 
 (defmethod print-method Task [t ^Writer w]
   (.write w


### PR DESCRIPTION
- Use `thaw` instead of the deprecated `thaw-from-byte-array`