### PR TITLE
Fixed up the regex on files

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,5 @@
-(defproject org.clojars.drbobbeaty/durable-queue "0.1.7"
+(defproject fractual/durable-queue "0.1.6"
   :description "a in-process task-queue that is backed by disk."
-  :url "http://github.com/drbobbeaty/durable-queue"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[com.taoensso/nippy "2.8.0"]
@@ -8,7 +7,7 @@
                  [byte-streams "0.2.2"]]
   :repositories [["releases" {:url "https://clojars.org/repo"
                               :creds :gpg}]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.7.0"]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.5.1"]
                                   [criterium "0.4.3"]
                                   [codox-md "0.2.0" :exclusions [org.clojure/clojure]]]}}
   :global-vars {*warn-on-reflection* true}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject factual/durable-queue "0.1.6"
+(defproject org.clojars.drbobbeaty/durable-queue "0.1.6"
   :description "a in-process task-queue that is backed by disk."
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/project.clj
+++ b/project.clj
@@ -1,12 +1,10 @@
-(defproject fractual/durable-queue "0.1.6"
+(defproject factual/durable-queue "0.1.6-SNAPSHOT"
   :description "a in-process task-queue that is backed by disk."
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[com.taoensso/nippy "2.8.0"]
                  [primitive-math "0.1.4"]
                  [byte-streams "0.2.2"]]
-  :repositories [["releases" {:url "https://clojars.org/repo"
-                              :creds :gpg}]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.5.1"]
                                   [criterium "0.4.3"]
                                   [codox-md "0.2.0" :exclusions [org.clojure/clojure]]]}}

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,14 @@
-(defproject org.clojars.drbobbeaty/durable-queue "0.1.6"
+(defproject org.clojars.drbobbeaty/durable-queue "0.1.7"
   :description "a in-process task-queue that is backed by disk."
+  :url "http://github.com/drbobbeaty/durable-queue"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[com.taoensso/nippy "2.8.0"]
                  [primitive-math "0.1.4"]
-                 [byte-streams "0.2.0"]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.5.1"]
+                 [byte-streams "0.2.2"]]
+  :repositories [["releases" {:url "https://clojars.org/repo"
+                              :creds :gpg}]]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.7.0"]
                                   [criterium "0.4.3"]
                                   [codox-md "0.2.0" :exclusions [org.clojure/clojure]]]}}
   :global-vars {*warn-on-reflection* true}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject factual/durable-queue "0.1.6-SNAPSHOT"
+(defproject factual/durable-queue "0.1.6"
   :description "a in-process task-queue that is backed by disk."
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/src/durable_queue.clj
+++ b/src/durable_queue.clj
@@ -348,7 +348,7 @@
    any existing files for that queue name."
   ([directory q-name queue size]
      (locking fs-monitor
-       (let [pattern (re-pattern (str "^" q-name "_(\\d{6})"))
+       (let [pattern (re-pattern (str "^" q-name "_(\\d{6}$)"))
              last-number (->> directory
                            io/file
                            .listFiles

--- a/src/durable_queue.clj
+++ b/src/durable_queue.clj
@@ -348,7 +348,7 @@
    any existing files for that queue name."
   ([directory q-name queue size]
      (locking fs-monitor
-       (let [pattern (re-pattern (str "^" q-name "_(\\d+)"))
+       (let [pattern (re-pattern (str "^" q-name "_(\\d{6})"))
              last-number (->> directory
                            io/file
                            .listFiles
@@ -398,8 +398,8 @@
   (let [queue->file (->> directory
                       io/file
                       .listFiles
-                      (filter #(re-find #"\w+_\d+" (.getName ^File %)))
-                      (group-by #(second (re-find #"(\w+)_\d+" (.getName ^File %)))))]
+                      (filter #(re-find #"^\w+_\d{6}$" (.getName ^File %)))
+                      (group-by #(second (re-find #"^(\w+)_\d{6}$" (.getName ^File %)))))]
     (zipmap
       (keys queue->file)
       (map


### PR DESCRIPTION
The regex for filtering the durable files needs to match the creation of
the names o fhte files, in order to make sure that we don't go looking
for files that aren't durable queue files.